### PR TITLE
v3.0.0 fix - ITemplate constructor arguments

### DIFF
--- a/src/Templates/ITemplate.php
+++ b/src/Templates/ITemplate.php
@@ -7,13 +7,13 @@ namespace WebChemistry\Invoice\Templates;
 use WebChemistry\Invoice\Data\Company;
 use WebChemistry\Invoice\Data\Customer;
 use WebChemistry\Invoice\Data\Order;
-use WebChemistry\Invoice\Formatter;
+use WebChemistry\Invoice\IFormatter;
 use WebChemistry\Invoice\ITranslator;
 use WebChemistry\Invoice\Renderers\IRenderer;
 
 interface ITemplate {
 
-	public function __construct(ITranslator $translator, Formatter $formatter);
+	public function __construct(ITranslator $translator, IFormatter $formatter);
 
 	public function build(IRenderer $renderer, Customer $customer, Order $order, Company $company): string;
 


### PR DESCRIPTION
Using a Formatter interface rather than class for the template constructor arguments